### PR TITLE
👷  Trigger CI for branches `dev/**`

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - develop
+      - dev/**
 
 jobs:
   lint:


### PR DESCRIPTION
Trigger CI workflow for branches named after the pattern `dev/**`, for development purpose