### PR TITLE
feat: introduce `Form` and remove `Action`

### DIFF
--- a/docs/source/user_guide/modelling_dom.ipynb
+++ b/docs/source/user_guide/modelling_dom.ipynb
@@ -125,9 +125,7 @@
    "id": "8de8cf3e",
    "metadata": {},
    "source": [
-    "We can now interact directly with the search by simply setting a value to `page.query`; this is the goal of `manen`: having very Pythonic way to retrieve and interact with a HTML page.\n",
-    "\n",
-    "In order to press *Enter*, you can use an `Action` that will trigger an event in the HTML page. Here by using `Action(\"submit\")`, we submit the form and so launching a search inside PyPI."
+    "We can now interact directly with the search by simply setting a value to `page.query`; this is the goal of `manen`: having very Pythonic way to retrieve and interact with a HTML page."
    ]
   },
   {
@@ -137,10 +135,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from manen.page_object_model.action import Action\n",
+    "from selenium.webdriver.common.keys import Keys\n",
     "\n",
     "page.query = \"manen selenium\"\n",
-    "page.query = Action(\"submit\")"
+    "page.query += Keys.ENTER"
    ]
   },
   {

--- a/manen/page_object_model/__init__.py
+++ b/manen/page_object_model/__init__.py
@@ -28,7 +28,10 @@ classes in an external file called ``pypi_pom.py``.
 
 
     class HomePage(Page):
-        query: Annotated[dom.Input, dom.CSS("input[name='q']")]
+        class SearchForm(Form):
+            query: Annotated[dom.Input, dom.CSS("input[name='q']")]
+
+        search: Annotated[SearchForm, dom.CSS("form.search-form")]
 
 
     class SearchResultPage(Page):
@@ -59,10 +62,9 @@ we will suppose that you have an instance of
 .. code-block:: python
 
     >>> from pypi_pom import HomePage, SearchResultPage
-    >>> from manen.page_object_model.element import Action
     >>> home_page = HomePage(driver)
-    >>> home_page.query = "selenium"
-    >>> home_page.query = Action("submit")
+    >>> home_page.search.query = "selenium"
+    >>> home_page.search.submit()
     # This will direct you to a search result page of PyPI.
     >>> page = SearchResultPage(driver)
     >>> page.nb_results

--- a/manen/page_object_model/dom.py
+++ b/manen/page_object_model/dom.py
@@ -66,5 +66,5 @@ InnerHTML = NewType("InnerHTML", str)
 OuterHTML = NewType("OuterHTML", str)
 HRef = NewType("HRef", str)
 ImageSrc = NewType("ImageSrc", str)
-Input = NewType("Input", str)
+Input = str
 Checkbox = NewType("Checkbox", str)

--- a/manen/page_object_model/element.py
+++ b/manen/page_object_model/element.py
@@ -69,13 +69,6 @@ class Elements(ImmutableDomComponent):
         ]
 
 
-class Action:
-    def __init__(self, method: str, *args, **kwargs):
-        self.method = method
-        self.args = args
-        self.kwargs = kwargs
-
-
 class InputElement:
     def __init__(self, config: dom.Config):
         if config.many:
@@ -100,16 +93,13 @@ class InputElement:
             default=NotImplemented,
             wait=self.config.wait,
         )
-        if isinstance(value, Action):
-            getattr(element, value.method)(*value.args, **value.kwargs)
-        else:
-            element.clear()
-            element.send_keys(value)
+        element.clear()
+        element.send_keys(value)
 
 
 class Region(ImmutableDomComponent):
-    def __get__(self, webarea: "WebArea", cls_webarea: type["WebArea"]):
-        from manen.page_object_model.webarea import WebArea
+    def __get__(self, webarea: "WebArea", cls_webarea: type["WebArea"]) -> "WebArea":
+        from manen.page_object_model.webarea import Form, WebArea
 
         element = find(
             selector=self.config.selectors,
@@ -119,7 +109,8 @@ class Region(ImmutableDomComponent):
             wait=self.config.wait,
         )
         name = self.config.element_type.__qualname__
-        cls = type(name, (WebArea,), {**self.config.element_type.__dict__})
+        base = (Form,) if Form.is_form(self.config.element_type) else (WebArea,)
+        cls = type(name, base, {**self.config.element_type.__dict__})
         return cls(element)
 
 

--- a/manen/page_object_model/webarea.py
+++ b/manen/page_object_model/webarea.py
@@ -29,8 +29,8 @@ class WebArea:
                 fn(config),
             )
 
-    @classmethod
-    def is_web_area(cls, element_type):
+    @staticmethod
+    def is_web_area(element_type):
         return type(element_type) is type and issubclass(element_type, WebArea)
 
     def model_dump(self):
@@ -44,6 +44,16 @@ class WebArea:
             else:
                 dump[field] = item
         return dump
+
+
+class Form(WebArea):
+    def submit(self):
+        assert isinstance(self._parent, WebElement)
+        self._parent.submit()
+
+    @staticmethod
+    def is_form(element_type):
+        return type(element_type) is type and issubclass(element_type, Form)
 
 
 class Page(WebArea):


### PR DESCRIPTION
### What's done?
- [x] Don't use a new type for `Input` but just a type alias for `str` (using a new type will create a type error when doing `page.input_element = "my value"`)
- [x] Assigning an `Action` to an input attribute wasn't OK for the type checker, so it has been removed. Instead, a `Form` web area is introduced, which can be used as a container for the input element and has a `submit` method.
- [x] Remove everything related to `Action` in the documentation
