### PR TITLE
fix: identification of input element

### DIFF
--- a/manen/page_object_model/dom.py
+++ b/manen/page_object_model/dom.py
@@ -14,6 +14,16 @@ class CSS:
 
 
 @dataclass
+class LinkText:
+    selector: str
+
+
+@dataclass
+class PartialLinkText:
+    selector: str
+
+
+@dataclass
 class Wait:
     seconds: int
 
@@ -48,8 +58,14 @@ class Config:
                 selectors.extend(config.selectors)
                 wait = config.wait
                 default = config.default
-            elif isinstance(config, (XPath, CSS)):
-                selectors.append(config.selector)
+            elif isinstance(config, XPath):
+                selectors.append(f"xpath:{config.selector}")
+            elif isinstance(config, CSS):
+                selectors.append(f"css:{config.selector}")
+            elif isinstance(config, LinkText):
+                selectors.append(f"link_text:{config.selector}")
+            elif isinstance(config, PartialLinkText):
+                selectors.append(f"partial_link_text:{config.selector}")
             elif isinstance(config, Wait):
                 wait = config.seconds
             elif isinstance(config, Default):

--- a/manen/page_object_model/webarea.py
+++ b/manen/page_object_model/webarea.py
@@ -4,7 +4,7 @@ from selenium.webdriver.chrome.webdriver import WebDriver
 from selenium.webdriver.remote.webelement import WebElement
 
 from manen.page_object_model import element
-from manen.page_object_model.dom import Config, Input
+from manen.page_object_model.dom import Config
 
 
 class WebArea:
@@ -19,7 +19,7 @@ class WebArea:
 
             if self.is_web_area(config.element_type):
                 fn = element.Regions if config.many else element.Region
-            elif config.element_type is Input:
+            elif config.is_input:
                 fn = element.InputElement
             else:
                 fn = element.Elements if config.many else element.Element


### PR DESCRIPTION
## What's done?
- [x] The identification of input elements was previously done with a check on the type `Input`, but given that it was a type alias of `str`, all the string elements were converted to `InputElement`, resulting to all strings being null. The identification of input element is now made with a flag, passed in the annotation.
- [x] Sort DOM elements
- [x] Add the selection method in the selector when building config