### PR TITLE
docs: use GitHub links for README images

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ browser = ChromeBrowser.initialize()
 browser.get("https://pypi.org")
 ```
 
-![PyPI home page](./docs/assets/screenshot_pypi_home.png)
+![PyPI home page](https://raw.githubusercontent.com/kodaho/manen/main/docs/assets/screenshot_pypi_home.png)
 
 We are now on the home page of PyPI. What we are going to do now is building a class that will
 inherit from `Page` from the `manen.page_object_model.webarea` module. This Python class will be
@@ -136,7 +136,7 @@ page.query += Keys.ENTER
 
 After submitting the form, we are redirected to the search results page.
 
-![PyPI home page](./docs/assets/screenshot_pypi_search_results.png)
+![PyPI home page](https://raw.githubusercontent.com/kodaho/manen/main/docs/assets/screenshot_pypi_search_results.png)
 
 The `SearchResultPage` will then be used to extract the results.
 

--- a/manen/__init__.py
+++ b/manen/__init__.py
@@ -17,4 +17,4 @@ use the module :py:mod:`~manen.finder` without :py:mod:`~manen.browser` or
 :py:mod:`~manen.page_object_model` without :py:mod:`~manen.browser`.
 """
 
-__version__ = "0.3.0.dev0"
+__version__ = "0.3.0.dev1"


### PR DESCRIPTION
Allow the images to be displayed correctly in the project description on PyPI.

Release: v0.3.0.dev1