### PR TITLE
fix: use static method in Chrome browser initialization

### DIFF
--- a/manen/__init__.py
+++ b/manen/__init__.py
@@ -17,4 +17,4 @@ use the module :py:mod:`~manen.finder` without :py:mod:`~manen.browser` or
 :py:mod:`~manen.page_object_model` without :py:mod:`~manen.browser`.
 """
 
-__version__ = "0.3.0.dev2"
+__version__ = "0.3.0.dev3"

--- a/manen/browser.py
+++ b/manen/browser.py
@@ -185,9 +185,8 @@ class BrowserMixin(WebDriverProtocol):
 class ChromeBrowser(BrowserMixin, Chrome):
     """Wrapper around Selenium ChromeWebDriver providing methods to improve its operability."""
 
-    @classmethod
+    @staticmethod
     def initialize(
-        cls,
         options: ChromeOptions | None = None,
         service: ChromeService | None = None,
         driver_path: str | None = None,
@@ -226,4 +225,4 @@ class ChromeBrowser(BrowserMixin, Chrome):
         if window_size:
             options.add_argument(f"--window-size={window_size[0]},{window_size[1]}")
 
-        return cls(options=options, service=service)
+        return Chrome(options=options, service=service)


### PR DESCRIPTION
## What's done
- [x] Fix initialization of `manen.browser.ChromeBrowser` by using a static method instead of class method

**Release:** 0.3.0.dev3