### PR TITLE
feat: add config validation and handle union type

### DIFF
--- a/docs/source/user_guide/page_object_model.ipynb
+++ b/docs/source/user_guide/page_object_model.ipynb
@@ -538,7 +538,7 @@
         "        Wait(5),\n",
         "    ]\n",
         "\n",
-        "    dont_exist: Annotated[str, CSS('i-dont-exist'), Default(None)]\n",
+        "    dont_exist: Annotated[str | None, CSS('i-dont-exist'), Default(None)]\n",
         "\n",
         "page = SearchResultPage(driver)"
       ]
@@ -551,6 +551,14 @@
       "outputs": [],
       "source": [
         "assert page.dont_exist is None"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "fb45e6e5",
+      "metadata": {},
+      "source": [
+        "Note that when using a default value, the type specified in the annotation should be coherent with the default value, with the restriction that only not-None type is allowed. For example, you can't have something like `Annotated[int | str, CSS('i-dont-exist'), Default('not here')]`."
       ]
     },
     {

--- a/manen/__init__.py
+++ b/manen/__init__.py
@@ -17,4 +17,4 @@ use the module :py:mod:`~manen.finder` without :py:mod:`~manen.browser` or
 :py:mod:`~manen.page_object_model` without :py:mod:`~manen.browser`.
 """
 
-__version__ = "0.3.0.dev4"
+__version__ = "0.3.0.dev5"

--- a/manen/page_object_model/config.py
+++ b/manen/page_object_model/config.py
@@ -92,4 +92,12 @@ class Config:
             kwargs.update({"element_type": get_args(type_)[0], "many": False})
         else:
             kwargs.update({"element_type": type_, "many": False})
-        return cls.merge(annotation.__metadata__, **kwargs)
+
+        config = cls.merge(annotation.__metadata__, **kwargs)
+
+        if len(config.selectors) == 0:
+            raise ValueError(
+                f"At least one selector should be specified in the annotation of '{field}'"
+            )
+
+        return config

--- a/manen/page_object_model/config.py
+++ b/manen/page_object_model/config.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Any, get_origin
+from types import UnionType
+from typing import Any, get_args, get_origin
 
 from manen.page_object_model.dom import Flag
 
@@ -86,7 +87,9 @@ class Config:
         origin = get_origin(type_ := annotation.__origin__)
         kwargs = {"name": field}
         if origin is list:
-            kwargs.update({"element_type": type_.__args__[0], "many": True})
+            kwargs.update({"element_type": get_args(type_)[0], "many": True})
+        elif origin is UnionType:
+            kwargs.update({"element_type": get_args(type_)[0], "many": False})
         else:
             kwargs.update({"element_type": type_, "many": False})
         return cls.merge(annotation.__metadata__, **kwargs)

--- a/manen/page_object_model/config.py
+++ b/manen/page_object_model/config.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
-from types import UnionType
+from types import NoneType, UnionType
 from typing import Any, get_args, get_origin
 
 from manen.page_object_model.dom import Flag
+from manen.page_object_model.exceptions import SelectorConfigError, TypeConfigError
 
 __all__ = ("CSS", "Default", "LinkText", "PartialLinkText", "Wait", "XPath")
 
@@ -86,18 +87,22 @@ class Config:
     def from_annotation_item(cls, field, annotation):
         origin = get_origin(type_ := annotation.__origin__)
         kwargs = {"name": field}
+
         if origin is list:
             kwargs.update({"element_type": get_args(type_)[0], "many": True})
+
         elif origin is UnionType:
-            kwargs.update({"element_type": get_args(type_)[0], "many": False})
+            args = [arg for arg in get_args(type_) if arg is not NoneType]
+            if len(args) != 1:
+                raise TypeConfigError(field, args)
+            kwargs.update({"element_type": args[0], "many": False})
+
         else:
             kwargs.update({"element_type": type_, "many": False})
 
         config = cls.merge(annotation.__metadata__, **kwargs)
 
         if len(config.selectors) == 0:
-            raise ValueError(
-                f"At least one selector should be specified in the annotation of '{field}'"
-            )
+            raise SelectorConfigError(field)
 
         return config

--- a/manen/page_object_model/exceptions.py
+++ b/manen/page_object_model/exceptions.py
@@ -1,0 +1,21 @@
+from manen.exceptions import ManenException
+
+
+class TypeConfigError(TypeError, ManenException):
+    def __init__(self, field, types):
+        self.field = field
+        self.types = types
+
+    def __str__(self):
+        return (
+            f"Field '{self.field}' should have exactly one non-None type in its annotation, but "
+            f"get {self.types}"
+        )
+
+
+class SelectorConfigError(ValueError, ManenException):
+    def __init__(self, field):
+        self.field = field
+
+    def __str__(self):
+        return f"At least one selector should be specified in the annotation of '{self.field}'"


### PR DESCRIPTION
## What's done?
- [x] Handle union type (for default value) in element annotation
- [x] Raise error during the config parsing if there is no selector or several types is specified

**Release**: v0.3.0.dev5