### PR TITLE
feat: improvements in `page_object_model.dom_value`

### DIFF
--- a/manen/__init__.py
+++ b/manen/__init__.py
@@ -17,4 +17,4 @@ use the module :py:mod:`~manen.finder` without :py:mod:`~manen.browser` or
 :py:mod:`~manen.page_object_model` without :py:mod:`~manen.browser`.
 """
 
-__version__ = "0.3.0a1"
+__version__ = "0.3.0a2"

--- a/manen/page_object_model/component.py
+++ b/manen/page_object_model/component.py
@@ -54,10 +54,6 @@ class Form(Component):
         assert isinstance(self._scope, WebElement)
         self._scope.submit()
 
-    @staticmethod
-    def is_form(element_type):
-        return type(element_type) is type and issubclass(element_type, Form)
-
 
 class Page(Component):
     @property

--- a/manen/page_object_model/component.py
+++ b/manen/page_object_model/component.py
@@ -34,7 +34,7 @@ class Component:
 
     @staticmethod
     def is_component(element_type):
-        return type(element_type) is type and issubclass(element_type, Component)
+        return issubclass(element_type, Component)
 
     def model_dump(self):
         dump = {}

--- a/manen/page_object_model/dom_value.py
+++ b/manen/page_object_model/dom_value.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, Annotated, Callable, TypeVar
+from typing import TYPE_CHECKING, Annotated, Callable, TypeVar, cast
 
 import dateparser
 from selenium.webdriver.remote.webelement import WebElement
@@ -139,8 +139,6 @@ class DOMSection(ImmutableDOMValueMixin, ConfigurableDOM):
         component: "Component",
         cls_webarea: type["Component"],
     ) -> "Component":
-        from manen.page_object_model.component import Component, Form
-
         element = find(
             selector=self.config.selectors,
             inside=component._scope,
@@ -148,10 +146,12 @@ class DOMSection(ImmutableDOMValueMixin, ConfigurableDOM):
             default=NotImplemented,
             wait=self.config.wait,
         )
-        name = self.config.element_type.__qualname__
-        base = (Form,) if Form.is_form(self.config.element_type) else (Component,)
-        cls = type(name, base, {**self.config.element_type.__dict__})
-        return cls(element)
+        cls = type(
+            self.config.element_type.__qualname__,
+            self.config.element_type.__bases__,
+            {**self.config.element_type.__dict__},
+        )
+        return cast("Component", cls(element))
 
 
 class DOMSections(ImmutableDOMValueMixin, ConfigurableDOM):
@@ -165,6 +165,9 @@ class DOMSections(ImmutableDOMValueMixin, ConfigurableDOM):
             default=NotImplemented,
             wait=self.config.wait,
         )
-        name = self.config.element_type.__qualname__
-        cls = type(name, (Component,), {**self.config.element_type.__dict__})
+        cls = type(
+            self.config.element_type.__qualname__,
+            self.config.element_type.__bases__,
+            {**self.config.element_type.__dict__},
+        )
         return [cls(element) for element in elements]

--- a/manen/page_object_model/dom_value.py
+++ b/manen/page_object_model/dom_value.py
@@ -42,7 +42,7 @@ class ImmutableDOMValueMixin:
 
 
 class DOMValue(ImmutableDOMValueMixin, ConfigurableDOM):
-    def __get__(self, component: "Component", unused_cls_webarea: type["Component"]):
+    def __get__(self, component: "Component", component_class: type["Component"]):
         element = find(
             selector=self.config.selectors,
             inside=component._scope,
@@ -61,7 +61,7 @@ class DOMValue(ImmutableDOMValueMixin, ConfigurableDOM):
 
 
 class DOMValues(ImmutableDOMValueMixin, ConfigurableDOM):
-    def __get__(self, component: "Component", unused_cls_webarea: type["Component"]):
+    def __get__(self, component: "Component", component_class: type["Component"]):
         elements = find(
             selector=self.config.selectors,
             inside=component._scope,
@@ -85,7 +85,7 @@ class InputDOMValue:
             raise ValueError("Cannot use InputElement with many=True")
         self.config = config
 
-    def __get__(self, component: "Component", unused_cls_webarea: type["Component"]):
+    def __get__(self, component: "Component", component_class: type["Component"]):
         element = find(
             selector=self.config.selectors,
             inside=component._scope,
@@ -111,7 +111,7 @@ class CheckboxDOMValue:
     def __init__(self, config: Config):
         self.config = config
 
-    def __get__(self, component: "Component", unused_cls_webarea: type["Component"]):
+    def __get__(self, component: "Component", component_class: type["Component"]):
         element = find(
             selector=self.config.selectors,
             inside=component._scope,
@@ -137,7 +137,7 @@ class DOMSection(ImmutableDOMValueMixin, ConfigurableDOM):
     def __get__(
         self,
         component: "Component",
-        cls_webarea: type["Component"],
+        component_class: type["Component"],
     ) -> "Component":
         element = find(
             selector=self.config.selectors,
@@ -155,9 +155,7 @@ class DOMSection(ImmutableDOMValueMixin, ConfigurableDOM):
 
 
 class DOMSections(ImmutableDOMValueMixin, ConfigurableDOM):
-    def __get__(self, component: "Component", cls_webarea: type["Component"]):
-        from manen.page_object_model.component import Component
-
+    def __get__(self, component: "Component", component_class: type["Component"]):
         elements = find(
             selector=self.config.selectors,
             inside=component._scope,


### PR DESCRIPTION
## What's done?
- [x] Don't use explicitly `Component` when building a component, but instead reuse the class bases provided directly by Python
- [x] Rename `unused_cls_webarea` into `component_class`
- [x] Remove useless condition `type(...) is type` when checking if a class is a component
- [x] Remove useless method `Form.is_form`

**Release:** v0.3.0a2